### PR TITLE
remove trailling spaces at the end of line

### DIFF
--- a/lib/brick.ex
+++ b/lib/brick.ex
@@ -1,33 +1,33 @@
 defmodule Tetris.Brick do
   defstruct [
-    name: :i, 
-    location: {40, 0}, 
-    rotation: 0, 
+    name: :i,
+    location: {40, 0},
+    rotation: 0,
     reflection: false
   ]
-  
+
   def new(), do: __struct__()
-  
+
   def new_random() do
     %{
-      name: random_name(), 
-      location: {40, 0}, 
-      rotation: random_rotation(), 
+      name: random_name(),
+      location: {40, 0},
+      rotation: random_rotation(),
       reflection: random_reflection()
     }
   end
-  
+
   def random_name() do
     ~w(i l z o t)a
 |> Enum.random  end
 
-  
+
   def random_rotation() do
     [0, 90, 180, 270]
     |> Enum.random
   end
 
-  
+
   def random_reflection() do
     [true, false]
     |> Enum.random

--- a/test/brick_test.exs
+++ b/test/brick_test.exs
@@ -1,11 +1,11 @@
 defmodule BrickTest do
   use ExUnit.Case
-  
+
   import Tetris.Brick
 
   test "Creates a new brick" do
     assert new_brick().name == :i
   end
-  
+
   def new_brick, do: new()
 end


### PR DESCRIPTION
In some editors trailing spaces at the end of line look like red block.

example:
https://superuser.com/questions/921920/display-trailing-spaces-in-vim

So if removed it look more clean.
It just a little tiny improvement, but I hope you will find it helpful.